### PR TITLE
Implement VOOG intro overlay targets

### DIFF
--- a/components/edicy-tools-variables.tpl
+++ b/components/edicy-tools-variables.tpl
@@ -86,4 +86,10 @@
   {% else %}
     {% assign front_page_content_cover_color_data_str = front_page_content_cover_color_data | json %}
   {% endif %}
+
+  {% comment %}VOOG intro popover targets. Add them where applicable popovers should appear.{% endcomment %}
+  {% capture edy_intro_add_page %}{% if editmode %}data-edy-intro-popover="edy-add-page"{% endif %}{% endcapture %}
+  {% capture edy_intro_add_lang %}{% if editmode %}data-edy-intro-popover="edy-add-lang"{% endif %}{% endcapture %}
+  {% capture edy_intro_edit_text %}{% if editmode %}data-edy-intro-popover="edy-edit-text"{% endif %}{% endcapture %}
+
 {% endcapture %}

--- a/components/langmenu.tpl
+++ b/components/langmenu.tpl
@@ -1,6 +1,6 @@
 {% if editmode or site.has_many_languages? %}
-  <nav class="lang-menu js-popup-menu js-menu-lang-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}" {{ edy_intro_add_lang }}>
-    <button role="button" class="lang-menu-btn js-popup-menu-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
+  <nav class="lang-menu js-popup-menu js-menu-lang-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+    <button role="button" class="lang-menu-btn js-popup-menu-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}" {{ edy_intro_add_lang }}>
       {% if editmode or flags_state == false %}
         <span class="lang-title">
           {% for language in site.languages %}{% if language.selected? %}{{ language.title }}{% endif %}{% endfor %}

--- a/components/langmenu.tpl
+++ b/components/langmenu.tpl
@@ -1,5 +1,5 @@
 {% if editmode or site.has_many_languages? %}
-  <nav class="lang-menu js-popup-menu js-menu-lang-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+  <nav class="lang-menu js-popup-menu js-menu-lang-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}" {{ edy_intro_add_lang }}>
     <button role="button" class="lang-menu-btn js-popup-menu-btn lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
       {% if editmode or flags_state == false %}
         <span class="lang-title">

--- a/components/mainmenu.tpl
+++ b/components/mainmenu.tpl
@@ -17,7 +17,7 @@
         <li>{% menubtn site.hidden_menuitems %}</li>
       {% endif %}
 
-      <li>{% menuadd %}</li>
+      <li {{ edy_intro_add_page }}>{% menuadd %}</li>
     {% endif %}
   </ul>
 </nav>

--- a/components/mainmenu.tpl
+++ b/components/mainmenu.tpl
@@ -17,7 +17,7 @@
         <li>{% menubtn site.hidden_menuitems %}</li>
       {% endif %}
 
-      <li {{ edy_intro_add_page }}>{% menuadd %}</li>
+      <li><div style="display: inline-block;" {{ edy_intro_add_page }}>{% menuadd %}</div></li>
     {% endif %}
   </ul>
 </nav>

--- a/layouts/blog_article.tpl
+++ b/layouts/blog_article.tpl
@@ -30,7 +30,7 @@
             </header>
             <section class="post-content">
               <div class="post-excerpt cfx formatted">{% editable article.excerpt %}</div>
-              <div class="post-body cfx formatted">{% editable article.body %}</div>
+              <div class="post-body cfx formatted" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
 
               {% if editmode %}
               <div class="post-tags">

--- a/layouts/blog_news.tpl
+++ b/layouts/blog_news.tpl
@@ -32,7 +32,7 @@
               {% endif %}
             </nav>
           </div>
-          <section class="content blog-content inner cfx">
+          <section class="content blog-content inner cfx" {{ edy_intro_edit_text }}>
             {% content %}
             {% if editmode %}<div style="padding-top: 20px">{% addbutton %}</div>{% endif %}
           </section>

--- a/layouts/common_page.tpl
+++ b/layouts/common_page.tpl
@@ -17,7 +17,7 @@
         <div class="container-wrap cfx">
           <div class="container">
             {% include "submenu" %}
-            <section class="content cfx formatted">
+            <section class="content cfx formatted" {{ edy_intro_edit_text }}>
               {% contentblock name="content_header" publish_default_content="true" %}<h1>{{ page.title }}</h1>{% endcontentblock %}
               {% content %}
             </section>

--- a/layouts/front_page.tpl
+++ b/layouts/front_page.tpl
@@ -26,7 +26,7 @@
                 <section class="content formatted js-background-type {{ front_page_content_cover_type }}">
                   <div class="tbl">
                     <div class="tbl-row">
-                      <div class="tbl-cell">
+                      <div class="tbl-cell" {{ edy_intro_edit_text }}>
                         {% content %}
                       </div>
                     </div>


### PR DESCRIPTION
Current targetable areas are:
```
data-edy-intro-popover="edy-add-page"
data-edy-intro-popover="edy-add-lang"
data-edy-intro-popover="edy-edit-text"
```