### PR TITLE
Display Voog reference only on front page

### DIFF
--- a/components/footer.tpl
+++ b/components/footer.tpl
@@ -6,7 +6,13 @@
       {%- assign footer_content_title_tooltip = "content_tooltip_all_pages_same_language" | lce -%}
       {% xcontent name="footer" title_tooltip=footer_content_title_tooltip %}
     </div>
-    <div class="voog-reference">{% loginblock %}{{ "footer_login_link" | lc }}{% endloginblock %}</div>
+    {% if site.branding.enabled? and page.path == blank %}
+      <div class="voog-reference">
+        {% loginblock %}
+          {{ "footer_login_link" | lc }}
+        {% endloginblock %}
+      </div>
+    {% endif %}
   </div>
   {% if page.private? %}
     <div class="signout-btn-pad"></div>

--- a/components/footer.tpl
+++ b/components/footer.tpl
@@ -6,7 +6,7 @@
       {%- assign footer_content_title_tooltip = "content_tooltip_all_pages_same_language" | lce -%}
       {% xcontent name="footer" title_tooltip=footer_content_title_tooltip %}
     </div>
-    {% if site.branding.enabled? and page.path == blank %}
+    {% if site.branding.enabled and page.path == blank %}
       <div class="voog-reference">
         {% loginblock %}
           {{ "footer_login_link" | lc }}


### PR DESCRIPTION
- Voog reference is now only displayed on the front page of site
- Reference is only displayed if site branding is enabled in site settings.

Closes #134 